### PR TITLE
Synced codes and improved for questions-and-answers/os-exec

### DIFF
--- a/q-and-a/os-exec/os-exec_test.go
+++ b/q-and-a/os-exec/os-exec_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/xml"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"strings"
 	"testing"
@@ -25,7 +24,7 @@ func getXMLFromCommand() io.Reader {
 	out, _ := cmd.StdoutPipe()
 
 	cmd.Start()
-	data, _ := ioutil.ReadAll(out)
+	data, _ := io.ReadAll(out)
 	cmd.Wait()
 
 	return bytes.NewReader(data)

--- a/questions-and-answers/os-exec.md
+++ b/questions-and-answers/os-exec.md
@@ -104,7 +104,7 @@ func getXMLFromCommand() io.Reader {
     out, _ := cmd.StdoutPipe()
 
     cmd.Start()
-    data, _ := ioutil.ReadAll(out)
+    data, _ := io.ReadAll(out)
     cmd.Wait()
 
     return bytes.NewReader(data)


### PR DESCRIPTION
日本語対応ありがとうございます 👍

`os-exec.md` を試しながら `ioutil` の差分を反映しました．
upstream 側（quii）では更新されていました．