### PR TITLE
Synced codes and improved for questions-and-answers/error-types

### DIFF
--- a/q-and-a/error-types/error-types_test.go
+++ b/q-and-a/error-types/error-types_test.go
@@ -2,7 +2,7 @@ package errortypes
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -30,7 +30,7 @@ func DumbGetter(url string) (string, error) {
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body) // ignoring err for brevity
+	body, _ := io.ReadAll(res.Body) // ignoring err for brevity
 
 	return string(body), nil
 }

--- a/q-and-a/error-types/v2/error-types_test.go
+++ b/q-and-a/error-types/v2/error-types_test.go
@@ -3,7 +3,7 @@ package errortypes
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,7 +31,7 @@ func DumbGetter(url string) (string, error) {
 	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body) // ignoring err for brevity
+	body, _ := io.ReadAll(res.Body) // ignoring err for brevity
 
 	return string(body), nil
 }

--- a/questions-and-answers/error-types.md
+++ b/questions-and-answers/error-types.md
@@ -10,7 +10,7 @@ description: Error types
 
 `Gopher Slack`の`Pedro`が尋ねる
 
-> `fmt.Errorf("%s is foo、got%s"、bar、baz)`のようなエラーを作成している場合、文字列値を比較せずに同等性をテストする方法はありますか？
+> `fmt.Errorf("%s must be foo, got %s", bar, baz)` のようなエラーを作成している場合、文字列値を比較せずに同等性をテストする方法はありますか？
 
 このアイデアを探索するのに役立つ関数を作りましょう。
 
@@ -28,7 +28,7 @@ func DumbGetter(url string) (string, error) {
     }
 
     defer res.Body.Close()
-    body, _ := ioutil.ReadAll(res.Body) // ignoring err for brevity
+    body, _ := io.ReadAll(res.Body) // ignoring err for brevity
 
     return string(body), nil
 }


### PR DESCRIPTION
日本語対応ありがとうございます 👍

`error-types.md` を試しながら `ioutil` の差分を反映しました．
upstream 側（quii）では更新されていました．